### PR TITLE
Adding checks to sample to see if NFC is available on the device

### DIFF
--- a/sample/res/values-fr/strings.xml
+++ b/sample/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="card_deleted">Données supprimées</string>
     <string name="card_reading_desc">Veuillez ne pas enlever ou bouger votre carte pendant la lecture.</string>
     <string name="nfc_locked">Paiement NFC désactivé sur votre carte</string>
-    <string name="msg_nfc_not_available">Ce dispositif n\'a pas NFC qui est nécessaire pour exécuter cette application.</string>
+    <string name="msg_nfc_not_available">Votre appareil n\'est pas compatible NFC. Cela est nécessaire pour le fonctionnement de l\'application.</string>
     <string name="msg_nfc_not_enabled">Veuillez activer le NFC et appuyez sur retour pour revenir sur l\'application.</string>
     <string name="msg_ok">OK</string>
     <string name="msg_info">Info</string>

--- a/sample/res/values-fr/strings.xml
+++ b/sample/res/values-fr/strings.xml
@@ -10,8 +10,9 @@
     <string name="card_deleted">Données supprimées</string>
     <string name="card_reading_desc">Veuillez ne pas enlever ou bouger votre carte pendant la lecture.</string>
     <string name="nfc_locked">Paiement NFC désactivé sur votre carte</string>
-    <string name="msg_nfc_disable">Veuillez activer le NFC et appuyez sur retour pour revenir sur l\'application.</string>
-    <string name="msg_activate_nfc">OK</string>
+    <string name="msg_nfc_not_available">Ce dispositif n\'a pas NFC qui est nécessaire pour exécuter cette application.</string>
+    <string name="msg_nfc_not_enabled">Veuillez activer le NFC et appuyez sur retour pour revenir sur l\'application.</string>
+    <string name="msg_ok">OK</string>
     <string name="msg_info">Info</string>
     <string name="donate_banner">Aidez nous à améliorer l\'application avec un don !</string>
     

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -10,8 +10,9 @@
     <string name="card_deleted">Card data deleted</string>
     <string name="card_reading_desc">Please do not remove or move card during reading.</string>
     <string name="nfc_locked">NFC is locked on your card</string>
-    <string name="msg_nfc_disable">Please enable NFC and press back to return to this application.</string>
-    <string name="msg_activate_nfc">OK</string>
+    <string name="msg_nfc_not_available">This device doesn't have NFC which is required to run this application.</string>
+    <string name="msg_nfc_not_enabled">Please enable NFC and press back to return to this application.</string>
+    <string name="msg_ok">OK</string>
     <string name="msg_info">Info</string>
     <string name="donate_banner">Help us to improve this app, donate !</string>
     

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="card_deleted">Card data deleted</string>
     <string name="card_reading_desc">Please do not remove or move card during reading.</string>
     <string name="nfc_locked">NFC is locked on your card</string>
-    <string name="msg_nfc_not_available">This device doesn't have NFC which is required to run this application.</string>
+    <string name="msg_nfc_not_available">This device doesn\'t have NFC which is required to run this application.</string>
     <string name="msg_nfc_not_enabled">Please enable NFC and press back to return to this application.</string>
     <string name="msg_ok">OK</string>
     <string name="msg_info">Info</string>

--- a/sample/src/main/java/com/github/devnied/emvnfccard/activity/HomeActivity.java
+++ b/sample/src/main/java/com/github/devnied/emvnfccard/activity/HomeActivity.java
@@ -215,7 +215,7 @@ public class HomeActivity extends FragmentActivity implements OnItemClickListene
 			AlertDialog.Builder alertbox = new AlertDialog.Builder(this);
 			alertbox.setTitle(getString(R.string.msg_info));
 			alertbox.setMessage(getString(R.string.msg_nfc_not_available));
-			alertbox.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+			alertbox.setPositiveButton(getString(R.string.msg_ok), new DialogInterface.OnClickListener() {
 				
 				@Override
 				public void onClick(final DialogInterface dialog, final int which) {
@@ -233,7 +233,7 @@ public class HomeActivity extends FragmentActivity implements OnItemClickListene
 			AlertDialog.Builder alertbox = new AlertDialog.Builder(this);
 			alertbox.setTitle(getString(R.string.msg_info));
 			alertbox.setMessage(getString(R.string.msg_nfc_not_enabled));
-			alertbox.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+			alertbox.setPositiveButton(getString(R.string.msg_ok), new DialogInterface.OnClickListener() {
 
 				@Override
 				public void onClick(final DialogInterface dialog, final int which) {

--- a/sample/src/main/java/com/github/devnied/emvnfccard/activity/HomeActivity.java
+++ b/sample/src/main/java/com/github/devnied/emvnfccard/activity/HomeActivity.java
@@ -207,14 +207,33 @@ public class HomeActivity extends FragmentActivity implements OnItemClickListene
 		if (mAlertDialog != null && mAlertDialog.isShowing()) {
 			mAlertDialog.cancel();
 		}
-		// Check NFC enable
-		if (!NFCUtils.isNfcEnable(getApplicationContext())) {
+		
+		// Check if NFC is available
+		if (!NFCUtils.isNfcAvailable(getApplicationContext())) {
 			backToHomeScreen();
 
 			AlertDialog.Builder alertbox = new AlertDialog.Builder(this);
 			alertbox.setTitle(getString(R.string.msg_info));
-			alertbox.setMessage(getString(R.string.msg_nfc_disable));
-			alertbox.setPositiveButton(getString(R.string.msg_activate_nfc), new DialogInterface.OnClickListener() {
+			alertbox.setMessage(getString(R.string.msg_nfc_not_available));
+			alertbox.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+				
+				@Override
+				public void onClick(final DialogInterface dialog, final int which) {
+					dialog.dismiss();
+				}
+			});
+			alertbox.setCancelable(false);
+			mAlertDialog = alertbox.show();
+		}
+		
+		// Check if NFC is enabled
+		if (!NFCUtils.isNfcEnabled(getApplicationContext())) {
+			backToHomeScreen();
+
+			AlertDialog.Builder alertbox = new AlertDialog.Builder(this);
+			alertbox.setTitle(getString(R.string.msg_info));
+			alertbox.setMessage(getString(R.string.msg_nfc_not_enabled));
+			alertbox.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
 
 				@Override
 				public void onClick(final DialogInterface dialog, final int which) {

--- a/sample/src/main/java/com/github/devnied/emvnfccard/utils/NFCUtils.java
+++ b/sample/src/main/java/com/github/devnied/emvnfccard/utils/NFCUtils.java
@@ -18,19 +18,37 @@ import android.nfc.tech.IsoDep;
 public class NFCUtils {
 
 	/**
-	 * Check if the NFCAdapter is enable
+	 * Check if NFC is available on the device
 	 * 
-	 * @return true if the NFCAdapter is available enable
+	 * @return true if the device has NFC available
 	 */
-	public static boolean isNfcEnable(final Context pContext) {
-		boolean ret = true;
+	public static boolean isNfcAvailable(final Context pContext) {
+		boolean nfcAvailable = true;
 		try {
-			NfcAdapter adpater = NfcAdapter.getDefaultAdapter(pContext);
-			ret = adpater != null && adpater.isEnabled();
+			NfcAdapter adapter = NfcAdapter.getDefaultAdapter(pContext);
+			if (adapter == null) {
+				nfcAvailable = false;
+			}
 		} catch (UnsupportedOperationException e) {
-			ret = false;
+			nfcAvailable = false;
 		}
-		return ret;
+		return nfcAvailable;
+	}
+	
+	/**
+	 * Check if NFC is enabled on the device
+	 * 
+	 * @return true if the device has NFC enabled
+	 */
+	public static boolean isNfcEnabled(final Context pContext) {
+		boolean nfcEnabled = true;
+		try {
+			NfcAdapter adapter = NfcAdapter.getDefaultAdapter(pContext);
+			nfcEnabled = adapter.isEnabled();
+		} catch (UnsupportedOperationException e) {
+			nfcEnabled = false;
+		}
+		return nfcEnabled;
 	}
 
 	/**


### PR DESCRIPTION
Making NFCUtils a bit more useful by allowing you to call a method to see if NFC is available on the device, and then another method to see if NFC is actually enabled on the device. This way you can easily tell apart a device that doesn't have NFC between a device that does have NFC but it's just turned off.

Updated the sample app to also use this to display a more informative message. Hopefully the French translation makes sense, had to use Google Translate!