### PR TITLE
Ensure list of parsers not null when the defaults are not added

### DIFF
--- a/library/src/main/java/com/github/devnied/emvnfccard/parser/EmvTemplate.java
+++ b/library/src/main/java/com/github/devnied/emvnfccard/parser/EmvTemplate.java
@@ -311,6 +311,7 @@ public class EmvTemplate {
 		if (config == null) {
 			config = Config();
 		}
+		parsers = new ArrayList<IParser>();
 		if (!config.removeDefaultParsers) {
 			addDefaultParsers();
 		}
@@ -321,7 +322,6 @@ public class EmvTemplate {
 	 * Add default parser implementation
 	 */
 	private void addDefaultParsers() {
-		parsers = new ArrayList<IParser>();
 		parsers.add(new GeldKarteParser(this));
 		parsers.add(new EmvParser(this));
 	}


### PR DESCRIPTION
Fixed a bug where the parsers list was null if the default parsers are not added. 